### PR TITLE
Add Solidity Syntax Highlighting 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
By default `.sol` files have no syntax highlighting, however this can be fixed with the changed proposed in this PR.

[This](https://medium.com/@danielque/psa-how-to-fix-githubs-syntax-highlighting-for-solidity-4e9867c540b6) article provides a pretty good overview why this functionality needs to be added manually. Additionally due to github caching, syntax highlighting may not be "triggered" until the file is altered, or a new commit is added.