### PR TITLE
WASM compatibility

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "ethsnarks"]
 	path = ethsnarks
 	url = https://github.com/HarryR/ethsnarks.git
+[submodule "wasm/emsdk"]
+	path = wasm/emsdk
+	url = https://github.com/emscripten-core/emsdk.git

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,10 @@ genkeys: build
 	mkdir -p $(KEYPATH)
 	$(BUILDPATH)/mixer_cli genkeys $(KEYPATH)/mixer.pk.raw $(KEYPATH)/mixer.vk.json
 
-test: genkeys solidity-test python-test
+test: genkeys selftest solidity-test python-test
+
+selftest:
+	$(BUILDPATH)/mixer_selftest $(KEYPATH)/test.pk.raw $(KEYPATH)/test.vk.json
 
 python-test: genkeys
 	make -C python test

--- a/circuit/CMakeLists.txt
+++ b/circuit/CMakeLists.txt
@@ -36,6 +36,8 @@ else()
     add_library(mixer SHARED mixer.cpp)
 endif()
 
+add_definitions(-DBINARY_OUTPUT -DCURVE_ALT_BN128 -DMONTGOMERY_OUTPUT -DNO_PROCPS -DNO_PT_COMPRESSION=1)
+
 target_link_libraries(mixer ethsnarks_common SHA3IUF)
 set_property(TARGET mixer PROPERTY POSITION_INDEPENDENT_CODE ON)
 
@@ -47,5 +49,8 @@ if (IOS_BUILD)
 else()
     add_executable(mixer_cli mixer_cli.cpp)
     target_link_libraries(mixer_cli ethsnarks_common SHA3IUF)
+
+    add_executable(mixer_selftest mixer_selftest.cpp)
+    target_link_libraries(mixer_selftest ethsnarks_common SHA3IUF)
 endif()
 

--- a/circuit/mixer.hpp
+++ b/circuit/mixer.hpp
@@ -13,6 +13,8 @@ extern "C"
 
     const extern size_t MIXER_TREE_DEPTH;
 
+    char *mixer_prove_json( const char *pk_file, const char *in_json );
+
     char *mixer_prove(
         const char *pk_file,
         const char *in_root,

--- a/circuit/mixer_selftest.cpp
+++ b/circuit/mixer_selftest.cpp
@@ -1,0 +1,79 @@
+#include "mixer.cpp"
+#include "stubs.hpp"
+
+using ethsnarks::ppT;
+using ethsnarks::mixer_witness;
+
+// TODO: change this when circuit inputs are changed
+static const char *selftest_proof_inputs_json = "{\"root\":\"10997780549811400708601504250471468195534978745431599276492721316290896218338\",\"wallet_address\":\"742769056376932917098136869028921629509414507844\",\"nullifier\":\"4122865252528855556151764751710800669589320451792353049178187261023293512954\",\"nullifier_secret\":\"38013247834874329155180715878624481281276991464893709827868698396437084\",\"address\":0,\"path\":[\"19321998414906712342737093331922571923461328494325615870852140381009276079041\",\"17296471688945713021042054900108821045192859417413320566181654591511652308323\",\"4832852105446597958495745596582249246190817345027389430471458078394903639834\",\"15461585713781279680447535913361668280097097610604253131987810512856082142108\",\"3769229681213467802270422158523493430161857055705140649626474846487042015294\",\"13647072325998791786887512624449791092179176488816171646493984798290104596073\",\"15878703434308824340339618970594258057165374118672855332783394926709017260312\",\"9818535244623190070553351286595164824271849851242010032077443835159358157641\",\"7922042747482293668273191578664256926795518592713187716634465425744689501095\",\"2789379477568327439974616531924765517697226176694772607766179476825856863254\",\"1005990462954276647377962471017597558634496836612490083107674994677711544070\",\"11969127117470424354039737501297729117493728984899640368626242601139714409309\",\"5344394176735217860849296704604296419896817858372607211534789260173133864770\",\"14116139569958633576637617144876714429777518811711593939929091541932333542283\",\"15047636386088019397123018594201170501174366319805738014399908655923285748980\"]}";
+
+
+int main( int argc, char **argv )
+{
+	if( argc < 3 ) {
+		fprintf(stderr, "Usage: mixer_selftest <test.pk.raw> <test.vk.json> [test.proof.json [test.inputs.json]]\n");
+		return 99;
+	}
+
+	const char *mixer_pk = argv[1];
+	const char *mixer_vk = argv[2];
+
+	ppT::init_public_params();
+
+	const mixer_witness witness = mixer_witness::fromJSON(selftest_proof_inputs_json);
+
+	// Generate & verify a proof, all in-memory
+	std::cerr << "Setting up gadget" << std::endl;
+	ProtoboardT pb;
+	ethsnarks::mod_mixer gadget(pb, "mixer");
+	gadget.generate_r1cs_constraints();
+	gadget.generate_r1cs_witness(witness);
+
+	std::cerr << "Generating key pair" << std::endl;
+	auto constraints = pb.get_constraint_system();
+    auto keypair = libsnark::r1cs_gg_ppzksnark_zok_generator<ppT>(constraints);
+
+    std::cerr << "Generating proof" << std::endl;
+    auto primary_input = pb.primary_input();
+    auto auxiliary_input = pb.auxiliary_input();
+    auto proof = libsnark::r1cs_gg_ppzksnark_zok_prover<ppT>(keypair.pk, primary_input, auxiliary_input);
+
+    std::cerr << "Verifying in-memory proof" << std::endl;
+    if( ! libsnark::r1cs_gg_ppzksnark_zok_verifier_strong_IC <ppT> (keypair.vk, primary_input, proof) ) {
+    	std::cerr << "Error: test 1 failed" << std::endl;
+    	return 1;
+    }
+
+	std::cerr << "Exporting keys to disk" << std::endl;
+	ethsnarks::vk2json_file(keypair.vk, mixer_vk);
+	ethsnarks::writeToFile<decltype(keypair.pk)>(mixer_pk, keypair.pk);
+
+	const auto proof_json = ethsnarks::proof_to_json(proof, primary_input);
+	if( argc > 2 ) {
+		std::ofstream proof_json_fh(argv[3]);
+		proof_json_fh << proof_json;
+		proof_json_fh.close();
+
+		if( argc > 3 ) {
+			std::ofstream proof_input_fh(argv[4]);
+			proof_input_fh << selftest_proof_inputs_json;
+			proof_input_fh.close();
+		}
+	}
+
+	std::cerr << "Verifying proof JSON, using VK from disk" << std::endl;
+	const auto vk_json = ethsnarks::vk2json(keypair.vk);	
+	if( ! ethsnarks::stub_verify(vk_json.c_str(), proof_json.c_str()) ) {
+		std::cerr << "Error: test 2 failed" << std::endl;
+    	return 2;
+	}
+
+	std::cerr << "Generating proof, using PK from disk" << std::endl;
+	const auto disk_proof_json = ethsnarks::stub_prove_from_pb(pb, mixer_pk);
+	if( ! ethsnarks::stub_verify(vk_json.c_str(), disk_proof_json.c_str()) ) {
+		std::cerr << "Error: test 3 failed" << std::endl;
+    	return 3;
+	}
+
+	return 0;
+}

--- a/solidity/Makefile
+++ b/solidity/Makefile
@@ -1,5 +1,12 @@
+TRUFFLE = ./node_modules/.bin/truffle
+
+all: test
+
 node_modules:
 	npm install
+
+testrpc:
+	npm run testrpc
 
 .PHONY: test
 test: node_modules
@@ -7,11 +14,13 @@ test: node_modules
 
 .PHONY: deploy
 deploy: node_modules
-	truffle migrate
+	$(TRUFFLE) migrate
 
 deploy-rinkeby: node_modules
-	truffle migrate --network localrinkeby
+	$(TRUFFLE) migrate --network localrinkeby
+
 deploy-ropsten: node_modules
-	truffle migrate --network ropsten
+	$(TRUFFLE) migrate --network ropsten
+
 deploy-mainnet: node_modules
-	truffle migrate --network mainnet
+	$(TRUFFLE) migrate --network mainnet

--- a/solidity/package.json
+++ b/solidity/package.json
@@ -7,6 +7,8 @@
   "author": "olivier@argent.xyz",
   "license": "ISC",
   "devDependencies": {
+    "truffle": "^5.0.29",
+    "ganache-cli": "^6.5.0",
     "bn-chai": "^1.0.1",
     "chai": "^4.2.0",
     "dotenv": "^8.0.0",

--- a/solidity/test/helpers/libmixer.js
+++ b/solidity/test/helpers/libmixer.js
@@ -7,6 +7,15 @@ module.exports = ffi.Library("../.build/libmixer", {
   // Retrieve depth of tree
   mixer_tree_depth: ["size_t", []],
 
+  // Create a proof for the parameters, using JSON arguments
+  mixer_prove_json: [
+    "string",
+    [
+      "string", // pk_file
+      "string"  // in_json
+    ]
+  ],
+
   // Create a proof for the parameters
   mixer_prove: [
     "string",

--- a/solidity/truffle.js
+++ b/solidity/truffle.js
@@ -5,7 +5,7 @@ module.exports = {
   networks: {
     development: {
       host: "localhost",
-      port: 7545,
+      port: 8545,
       network_id: "*", // Match any network id
       gas: 6.5e6 // Gas limit
     },

--- a/wasm/.gitignore
+++ b/wasm/.gitignore
@@ -1,0 +1,7 @@
+*.o
+build/
+build.emscripten/
+installroot/
+gmp-*
+test.pk.raw
+test.vk.json

--- a/wasm/CMakeLists.txt
+++ b/wasm/CMakeLists.txt
@@ -1,0 +1,54 @@
+cmake_minimum_required(VERSION 2.8)
+
+project(hopper-emscripten)
+
+set(CMAKE_VERBOSE_MAKEFILE on)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/build.emscripten)
+
+set(USE_ASM OFF)
+set(WITH_PROCPS OFF)
+set(DEBUG OFF)
+set(WITH_SUPERCOP OFF)
+set(CMAKE_CXX_FLAGS "--std=c++11 -fno-rtti -s ALLOW_MEMORY_GROWTH=1 -s FORCE_FILESYSTEM=1")
+# Debug options:
+# -s DISABLE_EXCEPTION_CATCHING=0 -g4 -s ASSERTIONS=0 -O0  -s EXCEPTION_DEBUG=1
+
+set(CMAKE_PREFIX_PATH ${CMAKE_CURRENT_SOURCE_DIR}/installroot)
+
+set(PKG_CONFIG_USE_CMAKE_PREFIX_PATH on)
+
+set(GMP_LIBRARY ${CMAKE_CURRENT_SOURCE_DIR}/installroot/lib/libgmp.a)
+set(GMP_INCLUDE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/installroot/include)
+set(GMP_LIBRARIES ${CMAKE_CURRENT_SOURCE_DIR}/installroot/lib/libgmp.a)
+
+
+
+include_directories(SYSTEM ${CMAKE_CURRENT_SOURCE_DIR}/installroot/include)
+
+add_subdirectory(../ethsnarks ethsnarks-build)
+
+
+add_definitions(-DBINARY_OUTPUT -DCURVE_ALT_BN128 -DMONTGOMERY_OUTPUT -DNO_PROCPS -DNO_PT_COMPRESSION=1)
+
+include_directories(../ethsnarks/src)
+include_directories(
+  ${DEPENDS_DIR}/json/single_include
+  ${DEPENDS_DIR}/SHA3IUF
+  ${DEPENDS_DIR}/libsnark
+  ${DEPENDS_DIR}/libsnark/depends/libff
+  ${DEPENDS_DIR}/libfqfft)
+
+add_library(mixer STATIC ../circuit/mixer.cpp)
+
+add_executable(mixer_cli ../circuit/mixer_cli.cpp)
+target_link_libraries(mixer_cli ethsnarks_common SHA3IUF)
+
+add_executable(mixer_selftest ../circuit/mixer_selftest.cpp)
+target_link_libraries(mixer_selftest ethsnarks_common SHA3IUF)
+
+add_executable(mixer_js ../circuit/mixer.cpp)
+target_link_libraries(mixer_js ethsnarks_common SHA3IUF)
+
+target_link_libraries(mixer_js "-s EXPORTED_FUNCTIONS=[\\\"_mixer_prove_json\\\",\\\"_mixer_verify\\\",\\\"_mixer_tree_depth\\\"] -s EXTRA_EXPORTED_RUNTIME_METHODS=[\\\"ccall\\\",\\\"cwrap\\\"] -s FORCE_FILESYSTEM=1 -s DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[\\\"$Browser\\\"]")
+#target_link_options(mixer_js PUBLIC "SHELL:-s EXPORTED_FUNCTIONS=[\\\"_mixer_prove_json\\\",\\\"_mixer_verify\\\",\\\"_mixer_tree_depth\\\"] -s DEFAULT_LIBRARY_FUNCS_TO_INCLUDE=[\\\"$Browser\\\"]")
+

--- a/wasm/Makefile
+++ b/wasm/Makefile
@@ -1,0 +1,104 @@
+ROOT_DIR := $(shell dirname "$(realpath $(lastword $(MAKEFILE_LIST)))")
+
+GMP_VERSION=6.1.2
+GMP_DIR=gmp-$(GMP_VERSION)
+GMP_TAR=$(GMP_DIR).tar.bz2
+GMP_URL=https://ftp.gnu.org/pub/gnu/gmp/$(GMP_TAR)
+GMP_MAKE_BINS=$(addprefix $(GMP_DIR)/, gen-fib gen-fac gen-bases gen-trialdivtab gen-jacobitab gen-psqr)
+
+FASTCOMP = emsdk/fastcomp
+
+OS := $(shell uname)
+
+
+#######################################################################
+
+
+all: emscripten gmp ethsnarks
+
+installroot:
+	mkdir -p $@
+
+build:
+	mkdir -p $@
+
+example-server:
+	php -t example -S 127.0.0.1:3333
+
+clean:
+	rm -rf build build.emscripten gmp-*
+
+
+#######################################################################
+# emscripten
+
+emscripten: $(FASTCOMP)/emscripten/emcc
+
+ifeq ($(OS), Darwin)
+emscripten: $(FASTCOMP)/bin/llvm-ar.old $(FASTCOMP)/fastcomp/bin/llvm-ar.old
+
+$(FASTCOMP)/bin/llvm-ar.old: $(FASTCOMP)/bin/llvm-ar
+	cd $(dir $@) && mv llvm-ar llvm-ar.old && ln -s /usr/local/opt/llvm/bin/llvm-ar llvm-ar
+
+$(FASTCOMP)/fastcomp/bin/llvm-ar.old: $(FASTCOMP)/fastcomp/bin/llvm-ar
+	cd $(dir $@) && mv llvm-ar llvm-ar.old && ln -s /usr/local/opt/llvm/bin/llvm-ar llvm-ar
+endif
+
+.PHONY: $(FASTCOMP)/emscripten/emcc
+$(FASTCOMP)/emscripten/emcc:
+	./emsdk/emsdk install latest
+	./emsdk/emsdk activate latest
+
+
+#######################################################################
+# ethsnarks
+
+ethsnarks-patches:
+	cd $(ROOT_DIR)/../ethsnarks/depends/libsnark/depends/libff && patch -Ntp1 < $(ROOT_DIR)/libff.patch || true
+
+ethsnarks: build.emscripten/mixer_cli.js
+
+cmake-patch:
+	sed -i.bak -e 's/$$$$Browser/$$Browser/' ./build/CMakeFiles/mixer_js.dir/link.txt
+
+build.emscripten/mixer_cli.js: build/cmake_install.cmake cmake-patch
+	make -C build mixer_cli mixer_js mixer_selftest
+	cp build.emscripten/mixer_js.* example/
+
+build/cmake_install.cmake: build ethsnarks-patches
+	cd build && emcmake cmake -DCMAKE_BUILD_TYPE=Release .. -DWITH_PROCPS=OFF -DPKG_CONFIG_USE_CMAKE_PREFIX_PATH=ON -DCMAKE_PREFIX_PATH=`pwd`/../installroot/ 
+
+
+#######################################################################
+# GMP
+
+gmp-bins: $(GMP_MAKE_BINS)
+
+.PHONY: gmp
+gmp: installroot/lib/libgmp.a
+
+installroot/lib/libgmp.a: installroot $(GMP_DIR) $(GMP_MAKE_BINS) $(GMP_DIR)/Makefile
+	make -C $(GMP_DIR) -j 2
+	make -C $(GMP_DIR) install
+
+$(GMP_DIR)/Makefile: $(GMP_DIR)
+	cd $< && sed -i.bak -e 's/^# Only do the GMP_ASM .*/gmp_asm_syntax_testing=no/' configure.ac && autoconf
+	cd $< && emcmake ./configure ABI=standard CFLAGS="-O3" --prefix=`pwd`/../installroot/ --host=none --disable-assembly --disable-shared || cat config.log
+
+$(GMP_DIR): $(GMP_TAR)
+	tar -xf $<
+
+$(GMP_TAR):
+	curl -L -o $@ $(GMP_URL)
+
+$(GMP_DIR)/gen-fib: $(GMP_DIR)/gen-fib.c
+
+$(GMP_DIR)/gen-fac: $(GMP_DIR)/gen-fac.c
+
+$(GMP_DIR)/gen-bases: $(GMP_DIR)/gen-bases.c
+
+$(GMP_DIR)/gen-trialdivtab: $(GMP_DIR)/gen-trialdivtab.c
+
+$(GMP_DIR)/gen-jacobitab: $(GMP_DIR)/gen-jacobitab.c
+
+$(GMP_DIR)/gen-psqr: $(GMP_DIR)/gen-psqr.c

--- a/wasm/README.md
+++ b/wasm/README.md
@@ -1,0 +1,19 @@
+# WASM support for Hopper
+
+For OSX, this requires `llvm-ar` at the following path:
+
+ * `/usr/local/opt/llvm/bin/llvm-ar`
+
+This can be installed via Brew, aka `brew install llvm`.
+
+Then, download, install and activate the Emscripten SDK:
+
+```
+./emsdk/emsdk install latest
+./emsdk/emsdk activate latest
+source emsdk/emsdk_env.sh
+```
+
+Then perform build by running:
+
+ * `make`

--- a/wasm/dump-keys.js
+++ b/wasm/dump-keys.js
@@ -1,0 +1,16 @@
+var path = require('path');
+var fs = require('fs');
+const _oldLoader = require.extensions['.js'];
+require.extensions['.js'] = function(mod, filename) {
+    if (filename == path.resolve(path.dirname(module.filename), 'build.emscripten/mixer_cli.js')) {
+        var content = require('fs').readFileSync(filename, 'utf8');
+        content += ";Module['FS']=FS;Module['NODEFS']=NODEFS;\n";
+        mod._compile(content, filename);
+    } else {
+        _oldLoader(mod, filename);
+    }
+};
+
+const emscripten_api = require('./build.emscripten/mixer_cli.js');
+const data = fs.readFileSync('../.keys/mixer.pk.raw');
+emscripten_api.FS.createDataFile("/", "pk.raw", data, true, false);

--- a/wasm/example/.gitignore
+++ b/wasm/example/.gitignore
@@ -1,0 +1,3 @@
+mixer_js.*
+mixer_selftest.*
+mixer_cli.*

--- a/wasm/example/index.html
+++ b/wasm/example/index.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<title>Hopper WASM example</title>
+		<script src="mixer_js.js" type="text/javascript"></script>
+	</head>
+
+	<body>
+		<script type="text/javascript">
+			var test_data = {"root": "0x25effa7ae6b15ce579b7e2c6b24169f7fd31571bafc8b5c00818220f0670057b", "wallet_address": "0x8e44d1193c827e2ef42224fb572b96b2c2c58c1b7eed91150fe6033817aa9c9", "nullifier": "0x29d5855566f660a056b57ef478b5905f5b4325688cc69fa084df8b40a76031cb", "nullifier_secret": "0xc767c65bf941db51ebe8e97b5aa9d0919019467b9b66adc778069a8430b3641", "address": 2, "path": ["0x17833f95bea2c44d5b98864eacb67c4aa45f5750cc26c034d2ce118aefc7f942", "0x55f7d551a50a60ab16daae0f849952762198b72f6b46e8b351728d2edaf1b1b", "0xaaf4c1f8c818c739b1ba6b1b2c09b4b90717da5038042be8ed43ac0ce3f371a", "0x222ef2884a14feeba44793cfb211970a3d116cbe65cf2694054ec69f4015d39c", "0x8554ef32b4a851765d3162c5e54eb97b01fcdd3c9e9592d7a3eafdaa123403e", "0x1e2bf81e1ace26df94fe8d049a25b0612e35a1fcae2f75dea45c3a94ef6cb669", "0x231b07146f4ee75bdd947481b16162a65a5b4baf8c85dde4470dc3c4c4a5b118", "0x15b5181133732369771c10c835330bf72bafc36f5220c396f55645275b733349", "0x1183b7a0d985f0d1ed7bc1eddf175b113b1d4938e48d8d74a5a81d6dadb213a7", "0x62abb9b25e1d325c5befa5b6aff18b688fdd4ef7ae1b46fcb3d7f991134ec16", "0x2395ed4209212a5ba691b12e87710080d26b189df3b77db84acb5bd34f29f06", "0x1a76492f398d15e4176dbed49010d6383c05e181fea2490ad5bb3b4e1350435d", "0xbd0d1e5853bc1f219596ab7fb759fba1c957ec3d1cfb0411ca0f23e2679df42", "0x1f3573ad2b248e5a71fe725d3a61511219c5945a8ad8207079c68aa0168f2b8b", "0x2144a90e5da8b039e17a97a5262f0eb3868554d5daee6b92654e85b4f61c6cf4"]};
+
+			Module['preRun'] = function () {
+				FS.createPreloadedFile("/", "mixer.pk.raw", "mixer.pk.raw", true, false);
+			};
+
+			Module['onRuntimeInitialized'] = function () {
+				alert('Starting Prove');
+			    var begin_prove = new Date().getTime() / 1000;
+				var mixer_prove_json = Module.cwrap('mixer_prove_json', 'string', ['string', 'string']);
+				var result = mixer_prove_json('/mixer.pk.raw', JSON.stringify(test_data));
+				var end_prove = new Date().getTime() / 1000;
+				alert(end_prove - begin_prove);
+				console.log(result);
+			};
+		</script>
+	</body>
+</html>

--- a/wasm/example/mixer.pk.raw
+++ b/wasm/example/mixer.pk.raw
@@ -1,0 +1,1 @@
+../../.keys/mixer.pk.raw

--- a/wasm/libff.patch
+++ b/wasm/libff.patch
@@ -1,0 +1,13 @@
+diff --git a/libff/common/profiling.cpp b/libff/common/profiling.cpp
+index f2a1985..665fa07 100755
+--- a/libff/common/profiling.cpp
++++ b/libff/common/profiling.cpp
+@@ -38,7 +38,7 @@ long long get_nsec_time()
+ /* Return total CPU time consumsed by all threads of the process, in nanoseconds. */
+ long long get_nsec_cpu_time()
+ {
+-#if _MSC_VER
++#if defined(_MSC_VER) || defined(__EMSCRIPTEN__)
+ 	return 0;
+ #else
+     ::timespec ts;

--- a/wasm/selftest.js
+++ b/wasm/selftest.js
@@ -1,0 +1,20 @@
+// Nasty hack to write files to local directory
+// Requires access to the FS and NODEFS local variables
+// These aren't accessible via the modules interface
+
+var path = require('path');
+const _oldLoader = require.extensions['.js'];
+require.extensions['.js'] = function(mod, filename) {
+    if (filename == path.resolve(path.dirname(module.filename), 'build.emscripten/mixer_selftest.js')) {
+        var content = require('fs').readFileSync(filename, 'utf8');
+        content += ";Module['FS']=FS;Module['NODEFS']=NODEFS;\n";
+        mod._compile(content, filename);
+    } else {
+        _oldLoader(mod, filename);
+    }
+};
+
+const emscripten_api = require('./build.emscripten/mixer_selftest.js');
+emscripten_api['FS'].mkdir('/working');
+emscripten_api['FS'].mount(emscripten_api['NODEFS'], { root: '.'}, '/working');
+emscripten_api.arguments = ['/working/test.pk.raw', '/working/test.vk.json', '/working/test.proof.json', '/working/test.inputs.json'];


### PR DESCRIPTION
This branch adds WASM build of Hopper using Emscripten.

 * ensures the build flags are the same across Native and WASM builds.
 * adds a circuit `selftest` executable, with hard-coded proof inputs
 * tests Native and WASM prover from the Truffle tests
